### PR TITLE
Fix the problem with ignoring markdown

### DIFF
--- a/src/main/java/com/github/shiraji/yaemoji/contributor/MarkdownEmojiCompletionContributor.kt
+++ b/src/main/java/com/github/shiraji/yaemoji/contributor/MarkdownEmojiCompletionContributor.kt
@@ -1,5 +1,6 @@
 package com.github.shiraji.yaemoji.contributor
 
+import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
 import org.intellij.plugins.markdown.lang.psi.impl.MarkdownCodeFenceImpl
 import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
@@ -7,4 +8,8 @@ import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
 class MarkdownEmojiCompletionContributor : EmojiCompletionContributor() {
     override val place = PlatformPatterns.psiElement().inside(MarkdownFile::class.java)
             .andNot(PlatformPatterns.psiElement().inside(MarkdownCodeFenceImpl::class.java))
+
+    init {
+        extend(CompletionType.BASIC, place, provider)
+    }
 }


### PR DESCRIPTION
This is the problem with Markdown's prefix matcher.
It always give me the empty string...

See #32 