### PR TITLE
Return prefix if the prefix is not contains ":"

### DIFF
--- a/src/main/java/com/github/shiraji/yaemoji/contributor/EmojiCompletionContributor.kt
+++ b/src/main/java/com/github/shiraji/yaemoji/contributor/EmojiCompletionContributor.kt
@@ -26,7 +26,7 @@ abstract class EmojiCompletionContributor(
 
     private fun PrefixMatcher.toEmojiPrefix(): String? {
         val currentPrefix = prefix
-        if (!currentPrefix.contains(Regex(":"))) return null
+        if (!currentPrefix.contains(Regex(":"))) return prefix
         val newPrefix = currentPrefix.split(Regex(":")).last()
         return if (newPrefix.contains(Regex("\\s"))) null else newPrefix
     }

--- a/src/test/java/com/github/shiraji/yaemoji/contributor/EmojiCompletionContributorTest.kt
+++ b/src/test/java/com/github/shiraji/yaemoji/contributor/EmojiCompletionContributorTest.kt
@@ -52,17 +52,20 @@ class EmojiCompletionContributorTest {
         }
 
         @Test
-        fun `Should do nothing if prefix does not contains semi colon`() {
+        fun `Should just pass the prefix if prefix does not contains semi colon`() {
             val parameters: CompletionParameters = mockk()
             every { parameters.completionType } returns CompletionType.BASIC
             every { parameters.position } returns mockk()
             every { mockPlace.accepts(any()) } returns true
             val result: CompletionResultSet = mockk()
             every { result.prefixMatcher.prefix } returns "asdfajsd"
+            val slot = slot<String>()
+            every { result.withPrefixMatcher(capture(slot)) } returns mockk()
+            every { provider.addCompletionVariants(any(), any(), any()) } just Runs
 
             target.fillCompletionVariants(parameters, result)
 
-            verify(exactly = 0) { provider.addCompletionVariants(any(), any(), any()) }
+            assertEquals("asdfajsd", slot.captured)
         }
 
         @Test


### PR DESCRIPTION
Some language does not pick ":" as a prefix. To overcome this
differencies, we don't eliminate the case if the prefix does not
contains ":". EmojiCompletionProvider already take care of the case if
there is no ":".

Fix #37 